### PR TITLE
Add generic API response wrapper and apply it to sign-in endpoint

### DIFF
--- a/src/main/java/com/example/worldFriend/controller/AuthController.java
+++ b/src/main/java/com/example/worldFriend/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.worldFriend.controller;
 
 
+import com.example.worldFriend.dto.AuthResponse;
 import com.example.worldFriend.dto.SigninDto;
+import com.example.worldFriend.generics.ApiResponse;
 import com.example.worldFriend.security.CustomUserDetails;
 import com.example.worldFriend.security.jwt.JwtUtils;
 import lombok.RequiredArgsConstructor;
@@ -29,17 +31,14 @@ public class AuthController {
     private final JwtUtils jwtUtils;
     private static Logger logger = LoggerFactory.getLogger(AuthController.class);
     @PostMapping("/signin")
-    public String signin(@RequestBody SigninDto signinRequest){
-        try {
+    public ResponseEntity<ApiResponse<AuthResponse>> signin(@RequestBody SigninDto signinRequest){
+
             Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(signinRequest.getUsername(),signinRequest.getPassword()));
             SecurityContextHolder.getContext().setAuthentication(authentication);
             logger.info("User principal: {}", authentication);
 
             String token = jwtUtils.generateToken(authentication);
 
-            return token;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+            return ResponseEntity.ok().body(ApiResponse.success("Login successful", new AuthResponse(token)));
     }
 }

--- a/src/main/java/com/example/worldFriend/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/worldFriend/controller/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.worldFriend.controller;
+
+
+import com.example.worldFriend.generics.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBadCredentials(){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("Invalid username or password"));
+    }
+}

--- a/src/main/java/com/example/worldFriend/dto/AuthResponse.java
+++ b/src/main/java/com/example/worldFriend/dto/AuthResponse.java
@@ -1,9 +1,12 @@
 package com.example.worldFriend.dto;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Data
+@RequiredArgsConstructor
+@Getter
 public class AuthResponse {
-
-    private String jwt;
+    private final String jwt;
+    private String type = "Bearer";
 }

--- a/src/main/java/com/example/worldFriend/generics/ApiResponse.java
+++ b/src/main/java/com/example/worldFriend/generics/ApiResponse.java
@@ -1,0 +1,28 @@
+package com.example.worldFriend.generics;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.springframework.stereotype.Component;
+
+@Getter
+public class ApiResponse<T> {
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success,String message, T data){
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data){
+        return new ApiResponse<>(true,message,data);
+    }
+
+    public static <T> ApiResponse<T> error(String message){
+        return new ApiResponse<>(false,message,null);
+    }
+}


### PR DESCRIPTION
Standardize API Responses Using Generic ApiResponse

This pull request introduces a generic ApiResponse<T> wrapper to standardize responses returned by the application.

Summary:

Added a reusable ApiResponse<T> structure containing success, message, and data

Designed as an immutable DTO with static factory methods for consistent usage

Applied the new response format to the sign-in endpoint to return structured authentication data

Why:

This change improves API consistency, simplifies frontend integration, and establishes a common response pattern for future endpoints.